### PR TITLE
Update GitHub Actions and versioning configuration

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,6 +63,17 @@ jobs:
         echo "fullSemVer=0.1.0-alpha.${{ github.run_number }}" >> $GITHUB_OUTPUT
       id: fallback_version
 
+    # Forward fallback_version outputs to gitversion outputs if GitVersion failed
+    - name: Forward fallback outputs to gitversion
+      if: steps.gitversion.outcome == 'failure'
+      run: |
+        echo "semVer=${{ steps.fallback_version.outputs.semVer }}" >> $GITHUB_OUTPUT
+        echo "nuGetVersionV2=${{ steps.fallback_version.outputs.nuGetVersionV2 }}" >> $GITHUB_OUTPUT
+        echo "assemblySemVer=${{ steps.fallback_version.outputs.assemblySemVer }}" >> $GITHUB_OUTPUT
+        echo "assemblySemFileVer=${{ steps.fallback_version.outputs.assemblySemFileVer }}" >> $GITHUB_OUTPUT
+        echo "informationalVersion=${{ steps.fallback_version.outputs.informationalVersion }}" >> $GITHUB_OUTPUT
+        echo "fullSemVer=${{ steps.fallback_version.outputs.fullSemVer }}" >> $GITHUB_OUTPUT
+      id: gitversion
     - name: Display GitVersion outputs
       run: |
         echo "SemVer: ${{ steps.gitversion.outputs.semVer }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,16 +25,43 @@ jobs:
         dotnet-version: '9.0.x'
 
     - name: Install GitVersion
-      uses: gittools/actions/gitversion/setup@v3.0.0
+      uses: gittools/actions/gitversion/setup@v3
       with:
         versionSpec: '6.x'
 
+    - name: Verify repository state
+      run: |
+        echo "Current directory:"
+        pwd
+        echo "Git status:"
+        git status
+        echo "Recent commits:"
+        git log --oneline -n 5
+        echo "GitVersion config:"
+        if [ -f GitVersion.yml ]; then
+          cat GitVersion.yml
+        else
+          echo "No GitVersion.yml found"
+        fi
+
     - name: Determine Version
       id: gitversion
-      uses: gittools/actions/gitversion/execute@v3.0.0
+      uses: gittools/actions/gitversion/execute@v3
       with:
         useConfigFile: true
         configFilePath: GitVersion.yml
+      continue-on-error: true
+
+    - name: Fallback to manual versioning if GitVersion fails
+      if: failure()
+      run: |
+        echo "semVer=0.1.0-alpha.${{ github.run_number }}" >> $GITHUB_OUTPUT
+        echo "nuGetVersionV2=0.1.0-alpha.${{ github.run_number }}" >> $GITHUB_OUTPUT
+        echo "assemblySemVer=0.1.0.0" >> $GITHUB_OUTPUT
+        echo "assemblySemFileVer=0.1.0.0" >> $GITHUB_OUTPUT
+        echo "informationalVersion=0.1.0-alpha.${{ github.run_number }}" >> $GITHUB_OUTPUT
+        echo "fullSemVer=0.1.0-alpha.${{ github.run_number }}" >> $GITHUB_OUTPUT
+      id: fallback_version
 
     - name: Display GitVersion outputs
       run: |

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,3 +1,4 @@
+next-version: 0.1.0
 mode: ContinuousDeployment
 branches:
   main:

--- a/SA1201ier.slnx
+++ b/SA1201ier.slnx
@@ -4,6 +4,10 @@
     <Platform Name="x64" />
     <Platform Name="x86" />
   </Configurations>
+  <Folder Name="/Solution Items/">
+    <File Path=".github/workflows/publish.yml" />
+    <File Path="GitVersion.yml" />
+  </Folder>
   <Project Path="SA1201ier.Cli/SA1201ier.csproj" />
   <Project Path="SA1201ier.Core/SA1201ier.Core.csproj" />
   <Project Path="SA1201ier.MSBuild/SA1201ier.MSBuild.csproj" />


### PR DESCRIPTION
Upgraded GitHub Actions workflows to use `dotnet-version` 9.0.x and updated GitVersion actions to v3. Added repository state verification and a fallback mechanism for manual versioning if GitVersion fails. Configured `GitVersion.yml` for ContinuousDeployment mode with `next-version` set to 0.1.0.

Included `.github/workflows/publish.yml` and `GitVersion.yml` in the solution file under `/Solution Items/`.