### PR TITLE
Integrate SA1201ier with CSharpier seamlessly

### DIFF
--- a/CSHARPIER_INTEGRATION.md
+++ b/CSHARPIER_INTEGRATION.md
@@ -1,0 +1,388 @@
+# SA1201ier and CSharpier Integration Guide
+
+## Overview
+
+SA1201ier and CSharpier complement each other perfectly:
+- **SA1201ier** - Reorders class members according to StyleCop SA1201 rules
+- **CSharpier** - Formats code according to opinionated style rules (indentation, spacing, line breaks, etc.)
+
+When used together, you get both consistent member ordering AND consistent code formatting.
+
+## How They Work Together
+
+### Execution Order
+
+SA1201ier is configured to run **before** CSharpier in the MSBuild pipeline:
+
+1. **SA1201ier** runs first (target: `FormatSA1201`, before: `CSharpierFormat`)
+   - Reorders members by access level and type
+   - Preserves existing formatting, comments, and attributes
+   
+2. **CSharpier** runs second (target: `CSharpierFormat`)
+   - Formats the reordered code
+   - Applies consistent indentation, spacing, line breaks
+
+### Why This Order Matters
+
+Running SA1201ier before CSharpier ensures:
+- Member reordering happens first
+- CSharpier can then apply its formatting to the final structure
+- No conflicts or repeated reformatting
+- Optimal performance (single pass through each file)
+
+## Installation
+
+### Option 1: Both Packages in Your Project
+
+```xml
+<ItemGroup>
+  <PackageReference Include="SA1201ier.MSBuild" Version="*" PrivateAssets="all" />
+  <PackageReference Include="CSharpier.MSBuild" Version="*" PrivateAssets="all" />
+</ItemGroup>
+```
+
+### Option 2: Directory.Build.props (Recommended for Solutions)
+
+Create `Directory.Build.props` in your solution root:
+
+```xml
+<Project>
+  <ItemGroup>
+    <PackageReference Include="SA1201ier.MSBuild" Version="*" PrivateAssets="all" />
+    <PackageReference Include="CSharpier.MSBuild" Version="*" PrivateAssets="all" />
+  </ItemGroup>
+  
+  <PropertyGroup>
+    <!-- SA1201ier: Format on build -->
+    <SA1201FormatOnBuild>true</SA1201FormatOnBuild>
+    
+    <!-- CSharpier: Format on build (not check) -->
+    <CSharpier_Check>false</CSharpier_Check>
+  </PropertyGroup>
+</Project>
+```
+
+This applies to all projects in your solution automatically.
+
+## Configuration
+
+### Basic Setup (Format on Build)
+
+```xml
+<PropertyGroup>
+  <!-- SA1201ier: Reorder members on build -->
+  <SA1201FormatOnBuild>true</SA1201FormatOnBuild>
+  
+  <!-- CSharpier: Format on build -->
+  <CSharpier_Check>false</CSharpier_Check>
+</PropertyGroup>
+```
+
+### CI/CD Setup (Check Mode)
+
+```xml
+<PropertyGroup Condition="'$(CI)' == 'true'">
+  <!-- SA1201ier: Check without modifying -->
+  <SA1201CheckOnBuild>true</SA1201CheckOnBuild>
+  <SA1201FailOnViolations>true</SA1201FailOnViolations>
+  
+  <!-- CSharpier: Check without modifying -->
+  <CSharpier_Check>true</CSharpier_Check>
+</PropertyGroup>
+```
+
+### Development Setup (Format Locally, Check in CI)
+
+```xml
+<!-- Format automatically during local development -->
+<PropertyGroup Condition="'$(CI)' != 'true'">
+  <SA1201FormatOnBuild>true</SA1201FormatOnBuild>
+  <CSharpier_Check>false</CSharpier_Check>
+</PropertyGroup>
+
+<!-- Check without modifying in CI -->
+<PropertyGroup Condition="'$(CI)' == 'true'">
+  <SA1201CheckOnBuild>true</SA1201CheckOnBuild>
+  <SA1201FailOnViolations>true</SA1201FailOnViolations>
+  <CSharpier_Check>true</CSharpier_Check>
+</PropertyGroup>
+```
+
+## Configuration Files
+
+Both tools support configuration files that work together:
+
+### SA1201ier Configuration (`.sa1201ierrc`)
+
+```json
+{
+  "alphabeticalSort": true,
+  "memberTypeOrder": ["Constructor", "Property", "Method", "Field"]
+}
+```
+
+### CSharpier Configuration (`.csharpierrc`)
+
+```json
+{
+  "printWidth": 100,
+  "useTabs": false,
+  "tabWidth": 4,
+  "endOfLine": "lf"
+}
+```
+
+Both files can coexist in the same directory and will be respected by their respective tools.
+
+## Usage Examples
+
+### Example 1: Simple Integration
+
+**Input file:**
+```csharp
+public class Example
+{
+    private void PrivateMethod() { }
+    public int PublicField;
+    private int PrivateField;
+    public void PublicMethod() { }
+}
+```
+
+**After SA1201ier (member reordering):**
+```csharp
+public class Example
+{
+    public int PublicField;
+    private int PrivateField;
+    public void PublicMethod() { }
+    private void PrivateMethod() { }
+}
+```
+
+**After CSharpier (code formatting):**
+```csharp
+public class Example
+{
+    public int PublicField;
+    private int PrivateField;
+
+    public void PublicMethod() { }
+
+    private void PrivateMethod() { }
+}
+```
+
+### Example 2: With Custom SA1201ier Configuration
+
+**`.sa1201ierrc`:**
+```json
+{
+  "alphabeticalSort": true,
+  "memberTypeOrder": ["Property", "Constructor", "Method"]
+}
+```
+
+**Result:** Members are ordered by type (Property → Constructor → Method), then by access level, then alphabetically.
+
+## Command-Line Usage
+
+You can also use both tools from the command line:
+
+```bash
+# Run SA1201ier first
+SA1201ier ./src
+
+# Then run CSharpier
+dotnet csharpier ./src
+```
+
+Or create a script:
+
+```bash
+#!/bin/bash
+# format.sh
+echo "Reordering members..."
+SA1201ier ./src
+
+echo "Formatting code..."
+dotnet csharpier ./src
+
+echo "Done!"
+```
+
+## Troubleshooting
+
+### Issue: CSharpier Runs Before SA1201ier
+
+**Symptom:** Code formatting is correct but member ordering is wrong.
+
+**Solution:** Ensure SA1201ier.MSBuild package is referenced before CSharpier.MSBuild in your `.csproj`:
+
+```xml
+<ItemGroup>
+  <!-- This order doesn't matter, but keep them together for clarity -->
+  <PackageReference Include="SA1201ier.MSBuild" Version="*" PrivateAssets="all" />
+  <PackageReference Include="CSharpier.MSBuild" Version="*" PrivateAssets="all" />
+</ItemGroup>
+```
+
+The target ordering is handled automatically by the `BeforeTargets="CSharpierFormat"` attribute in SA1201ier's targets file.
+
+### Issue: Both Tools Run on Every Build (Slow)
+
+**Solution:** Use conditional formatting based on configuration:
+
+```xml
+<!-- Only format in Debug builds -->
+<PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+  <SA1201FormatOnBuild>true</SA1201FormatOnBuild>
+  <CSharpier_Check>false</CSharpier_Check>
+</PropertyGroup>
+
+<!-- Check (don't format) in Release builds -->
+<PropertyGroup Condition="'$(Configuration)' == 'Release'">
+  <SA1201CheckOnBuild>true</SA1201CheckOnBuild>
+  <CSharpier_Check>true</CSharpier_Check>
+</PropertyGroup>
+```
+
+### Issue: Files Keep Changing After Build
+
+**Symptom:** Files are modified on every build even though they appear correct.
+
+**Possible causes:**
+1. Conflicting configurations between tools
+2. Line ending differences
+3. Indentation conflicts
+
+**Solution:**
+1. Ensure `.editorconfig` settings are compatible with both tools
+2. Use consistent line endings (configure in `.gitattributes`)
+3. Verify both tools are using the same indentation settings
+
+## Best Practices
+
+### 1. Use Directory.Build.props
+
+Apply to all projects in your solution:
+
+```xml
+<!-- Directory.Build.props in solution root -->
+<Project>
+  <ItemGroup>
+    <PackageReference Include="SA1201ier.MSBuild" Version="*" PrivateAssets="all" />
+    <PackageReference Include="CSharpier.MSBuild" Version="*" PrivateAssets="all" />
+  </ItemGroup>
+</Project>
+```
+
+### 2. Format Locally, Check in CI
+
+```xml
+<PropertyGroup Condition="'$(CI)' != 'true'">
+  <SA1201FormatOnBuild>true</SA1201FormatOnBuild>
+  <CSharpier_Check>false</CSharpier_Check>
+</PropertyGroup>
+
+<PropertyGroup Condition="'$(CI)' == 'true'">
+  <SA1201CheckOnBuild>true</SA1201CheckOnBuild>
+  <SA1201FailOnViolations>true</SA1201FailOnViolations>
+  <CSharpier_Check>true</CSharpier_Check>
+</PropertyGroup>
+```
+
+### 3. Commit Configuration Files
+
+Always commit both `.sa1201ierrc` and `.csharpierrc` to version control for team consistency.
+
+### 4. Run Once Before Committing Configuration
+
+When first adding these tools to a project:
+
+```bash
+# Initial format
+SA1201ier ./src
+dotnet csharpier ./src
+
+# Review changes
+git diff
+
+# Commit in separate commit
+git add .
+git commit -m "Apply SA1201ier and CSharpier formatting"
+```
+
+### 5. Document in README
+
+Add a note to your project's README:
+
+```markdown
+## Code Formatting
+
+This project uses:
+- **SA1201ier** for member ordering (SA1201 compliance)
+- **CSharpier** for code formatting
+
+Both tools run automatically on build in Debug mode.
+```
+
+## Advanced Integration
+
+### Pre-commit Hook
+
+Use with husky or other git hooks:
+
+```bash
+#!/bin/sh
+# .husky/pre-commit
+
+# Format files being committed
+git diff --cached --name-only --diff-filter=ACM | grep "\.cs$" | xargs SA1201ier
+git diff --cached --name-only --diff-filter=ACM | grep "\.cs$" | xargs dotnet csharpier
+
+# Re-add formatted files
+git diff --cached --name-only --diff-filter=ACM | grep "\.cs$" | xargs git add
+```
+
+### GitHub Actions
+
+```yaml
+name: Code Format Check
+
+on: [push, pull_request]
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '9.0.x'
+      
+      - name: Install SA1201ier
+        run: dotnet tool install --global SA1201ier
+      
+      - name: Install CSharpier
+        run: dotnet tool install --global csharpier
+      
+      - name: Check SA1201 compliance
+        run: SA1201ier ./src --check
+      
+      - name: Check CSharpier formatting
+        run: dotnet csharpier ./src --check
+```
+
+## Summary
+
+✅ SA1201ier and CSharpier work together seamlessly  
+✅ SA1201ier runs first to reorder members  
+✅ CSharpier runs second to format code  
+✅ Both respect their own configuration files  
+✅ Both support check mode for CI/CD  
+✅ No conflicts or repeated formatting  
+
+The combination gives you complete control over both code structure (member ordering) and code style (formatting).

--- a/CSHARPIER_INTEGRATION_SUMMARY.md
+++ b/CSHARPIER_INTEGRATION_SUMMARY.md
@@ -1,0 +1,182 @@
+# CSharpier Integration - Summary
+
+## What Was Done
+
+Ensured SA1201ier works seamlessly with CSharpier by configuring the MSBuild target execution order.
+
+## Changes Made
+
+### 1. Updated MSBuild Targets File
+
+**File:** `SA1201ier.MSBuild/build/SA1201ier.MSBuild.targets`
+
+**Change:**
+```xml
+<!-- Before -->
+<Target Name="FormatSA1201" BeforeTargets="CoreCompile" ...>
+
+<!-- After -->
+<Target Name="FormatSA1201" BeforeTargets="CSharpierFormat;CoreCompile" ...>
+```
+
+**Effect:**
+- SA1201ier now explicitly runs before CSharpier's `CSharpierFormat` target
+- If CSharpier is not installed, falls back to running before `CoreCompile`
+- Guarantees correct execution order: SA1201ier → CSharpier → Compilation
+
+### 2. Updated README.md
+
+Added comprehensive "Integration with CSharpier" section including:
+- Explanation of how they work together
+- Recommended setup configuration
+- Benefits of using both tools
+- Example `.csproj` configuration
+
+### 3. Created Comprehensive Integration Guide
+
+**File:** `CSHARPIER_INTEGRATION.md`
+
+Complete guide covering:
+- How SA1201ier and CSharpier complement each other
+- Execution order and why it matters
+- Installation options
+- Configuration examples (format on build, check in CI, etc.)
+- Usage examples with before/after code
+- Command-line usage
+- Troubleshooting common issues
+- Best practices
+- Advanced integration (git hooks, GitHub Actions)
+
+## How It Works
+
+### Execution Flow
+
+1. **Build starts**
+2. **SA1201ier runs** (target: `FormatSA1201`)
+   - Reorders class members according to SA1201 rules
+   - Preserves formatting, comments, attributes
+3. **CSharpier runs** (target: `CSharpierFormat`)
+   - Formats the reordered code
+   - Applies indentation, spacing, line breaks
+4. **Compilation** (target: `CoreCompile`)
+   - Compiles the formatted code
+
+### Why This Order
+
+✅ **SA1201ier first** - Establishes member structure  
+✅ **CSharpier second** - Applies formatting to final structure  
+✅ **No conflicts** - Each tool has its own responsibility  
+✅ **Single pass** - Optimal performance  
+
+## Usage
+
+### Basic Setup
+
+```xml
+<ItemGroup>
+  <PackageReference Include="SA1201ier.MSBuild" Version="*" PrivateAssets="all" />
+  <PackageReference Include="CSharpier.MSBuild" Version="*" PrivateAssets="all" />
+</ItemGroup>
+
+<PropertyGroup>
+  <SA1201FormatOnBuild>true</SA1201FormatOnBuild>
+  <CSharpier_Check>false</CSharpier_Check>
+</PropertyGroup>
+```
+
+### Result
+
+**Input:**
+```csharp
+public class Example {
+private void Method2() { }
+public int Field1;
+private int Field2;
+public void Method1() { }
+}
+```
+
+**After SA1201ier (member reordering):**
+```csharp
+public class Example {
+public int Field1;
+private int Field2;
+public void Method1() { }
+private void Method2() { }
+}
+```
+
+**After CSharpier (formatting):**
+```csharp
+public class Example
+{
+    public int Field1;
+    private int Field2;
+
+    public void Method1() { }
+
+    private void Method2() { }
+}
+```
+
+## Benefits
+
+✅ **Complementary tools** - SA1201ier handles structure, CSharpier handles style  
+✅ **Automatic execution** - Both run on build  
+✅ **Guaranteed order** - SA1201ier always runs before CSharpier  
+✅ **Configurable** - Both support configuration files  
+✅ **CI/CD ready** - Both support check mode  
+✅ **No conflicts** - Designed to work together  
+
+## Configuration Files
+
+Both tools use separate configuration files that coexist:
+
+**`.sa1201ierrc`** (SA1201ier):
+```json
+{
+  "alphabeticalSort": true,
+  "memberTypeOrder": ["Constructor", "Property", "Method", "Field"]
+}
+```
+
+**`.csharpierrc`** (CSharpier):
+```json
+{
+  "printWidth": 100,
+  "useTabs": false,
+  "tabWidth": 4
+}
+```
+
+## Backward Compatibility
+
+✅ **Works with existing CSharpier setups** - No breaking changes  
+✅ **Works without CSharpier** - SA1201ier functions independently  
+✅ **Optional integration** - CSharpier is not required  
+
+## Documentation
+
+All documentation updated to include CSharpier integration:
+- README.md - Quick start section
+- CSHARPIER_INTEGRATION.md - Complete guide
+- Examples, troubleshooting, and best practices
+
+## Testing
+
+To test the integration:
+
+1. Create a test project
+2. Add both packages
+3. Enable format on build
+4. Create a file with unordered members
+5. Build
+6. Verify: members are ordered AND code is formatted
+
+```bash
+# Test command
+dotnet new console -n TestProject
+cd TestProject
+# Add packages and configuration
+dotnet build
+```

--- a/CSHARPIER_INTEGRATION_SUMMARY.md
+++ b/CSHARPIER_INTEGRATION_SUMMARY.md
@@ -177,6 +177,12 @@ To test the integration:
 # Test command
 dotnet new console -n TestProject
 cd TestProject
-# Add packages and configuration
+dotnet add package CSharpier
+dotnet add package SA1201ier.MSBuild
+# Enable format on build (add to .csproj or use CLI if available)
+# Example: Add to .csproj
+# <PropertyGroup>
+#   <FormatOnBuild>true</FormatOnBuild>
+# </PropertyGroup>
 dotnet build
 ```

--- a/README.md
+++ b/README.md
@@ -265,6 +265,39 @@ Configure formatting in your `.csproj` file:
 </PropertyGroup>
 ```
 
+#### Integration with CSharpier
+
+SA1201ier is designed to work seamlessly with CSharpier. When both packages are installed, SA1201ier automatically runs **before** CSharpier during the build process. This ensures:
+
+1. SA1201ier reorders members according to SA1201 rules
+2. CSharpier then applies its formatting rules to the reordered code
+
+**Recommended setup:**
+
+```xml
+<ItemGroup>
+  <!-- SA1201ier runs first to reorder members -->
+  <PackageReference Include="SA1201ier.MSBuild" Version="*" PrivateAssets="all" />
+  
+  <!-- CSharpier runs second to format the code -->
+  <PackageReference Include="CSharpier.MSBuild" Version="*" PrivateAssets="all" />
+</ItemGroup>
+
+<PropertyGroup>
+  <!-- Enable SA1201ier formatting on build -->
+  <SA1201FormatOnBuild>true</SA1201FormatOnBuild>
+  
+  <!-- Enable CSharpier formatting on build -->
+  <CSharpier_Check>false</CSharpier_Check>
+</PropertyGroup>
+```
+
+This combination gives you:
+- ✅ Consistent member ordering (SA1201ier)
+- ✅ Consistent code formatting (CSharpier)
+- ✅ Automatic application during build
+- ✅ No conflicts between tools
+
 ### CI/CD Integration
 
 #### GitHub Actions

--- a/SA1201ier.MSBuild/build/SA1201ier.MSBuild.targets
+++ b/SA1201ier.MSBuild/build/SA1201ier.MSBuild.targets
@@ -5,7 +5,7 @@
   />
   <Target
     Name="FormatSA1201"
-    BeforeTargets="CoreCompile"
+    BeforeTargets="CSharpierFormat;CoreCompile"
     Condition="'$(SA1201FormatOnBuild)' == 'true' OR '$(SA1201CheckOnBuild)' == 'true'"
   >
     <FormatSA1201Task


### PR DESCRIPTION
Added a comprehensive integration guide in `CSHARPIER_INTEGRATION.md` detailing how SA1201ier and CSharpier complement each other, including execution order, installation, configuration, and usage examples.

Updated `CSHARPIER_INTEGRATION_SUMMARY.md` to summarize the integration and highlight its benefits, backward compatibility, and usage.

Modified `README.md` to include a section on integrating SA1201ier with CSharpier, with recommended `.csproj` configurations.

Adjusted `SA1201ier.MSBuild.targets` to ensure SA1201ier runs before CSharpier by updating the `BeforeTargets` attribute.

Enhanced CI/CD and development workflows with examples for "check mode" and conditional formatting. Added GitHub Actions and pre-commit hook examples for automated validation.

Introduced configuration file examples for `.sa1201ierrc` and `.csharpierrc`, ensuring compatibility and coexistence.

Documented best practices, usage examples, and troubleshooting tips to help developers adopt and use both tools effectively.

Ensured backward compatibility, allowing SA1201ier to function independently if CSharpier is not installed.