### PR TITLE
Update package versions to use version ranges

### DIFF
--- a/SA1201ier.Core/SA1201ier.Core.csproj
+++ b/SA1201ier.Core/SA1201ier.Core.csproj
@@ -23,7 +23,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="[4.8.0,5.0.0)" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Enums\" />

--- a/SA1201ier.MSBuild/SA1201ier.MSBuild.csproj
+++ b/SA1201ier.MSBuild/SA1201ier.MSBuild.csproj
@@ -30,7 +30,7 @@
     </PackageReference>
     <PackageReference
       Include="Microsoft.Build.Utilities.Core"
-      Version="17.14.8"
+      Version="[17.4.0,18.0.0)"
       PrivateAssets="all"
     />
   </ItemGroup>


### PR DESCRIPTION
Updated `Microsoft.CodeAnalysis.CSharp` in `SA1201ier.Core.csproj` to use the version range `[4.8.0,5.0.0)` for greater flexibility.

Updated `Microsoft.Build.Utilities.Core` in `SA1201ier.MSBuild.csproj` to use the version range `[17.4.0,18.0.0)` to allow compatibility with a broader set of versions.