### PR TITLE
Enable packaging improvements and default formatting

### DIFF
--- a/SA1201ier.MSBuild/SA1201ier.MSBuild.csproj
+++ b/SA1201ier.MSBuild/SA1201ier.MSBuild.csproj
@@ -39,7 +39,11 @@
   <ItemGroup>
     <None Include="build\**" Pack="true" PackagePath="build\" />
     <!-- Include all DLLs from output directory except MSBuild assemblies -->
-    <None Include="$(OutputPath)\*.dll" Pack="true" PackagePath="build\net9.0\" 
-          Exclude="$(OutputPath)\Microsoft.Build.*.dll" />
+    <None
+      Include="$(OutputPath)\*.dll"
+      Pack="true"
+      PackagePath="build\net9.0\"
+      Exclude="$(OutputPath)\Microsoft.Build.*.dll"
+    />
   </ItemGroup>
 </Project>

--- a/SA1201ier.MSBuild/SA1201ier.MSBuild.csproj
+++ b/SA1201ier.MSBuild/SA1201ier.MSBuild.csproj
@@ -16,6 +16,8 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <DevelopmentDependency>true</DevelopmentDependency>
     <IncludeBuildOutput>false</IncludeBuildOutput>
+    <!-- Copy all dependencies to output directory so they can be packaged -->
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\README.md" Pack="true" PackagePath="\" />
@@ -36,7 +38,8 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="build\**" Pack="true" PackagePath="build\" />
-    <None Include="$(OutputPath)\SA1201ier.MSBuild.dll" Pack="true" PackagePath="build\net9.0\" />
-    <None Include="$(OutputPath)\SA1201ier.Core.dll" Pack="true" PackagePath="build\net9.0\" />
+    <!-- Include all DLLs from output directory except MSBuild assemblies -->
+    <None Include="$(OutputPath)\*.dll" Pack="true" PackagePath="build\net9.0\" 
+          Exclude="$(OutputPath)\Microsoft.Build.*.dll" />
   </ItemGroup>
 </Project>

--- a/SA1201ier.MSBuild/build/SA1201ier.MSBuild.props
+++ b/SA1201ier.MSBuild/build/SA1201ier.MSBuild.props
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
-    <SA1201FormatOnBuild Condition="'$(SA1201FormatOnBuild)' == ''">false</SA1201FormatOnBuild>
+    <!-- Enable SA1201 formatting by default when the package is installed -->
+    <SA1201FormatOnBuild Condition="'$(SA1201FormatOnBuild)' == ''">true</SA1201FormatOnBuild>
     <SA1201CheckOnBuild Condition="'$(SA1201CheckOnBuild)' == ''">false</SA1201CheckOnBuild>
     <SA1201FailOnViolations Condition="'$(SA1201FailOnViolations)' == ''"
       >false</SA1201FailOnViolations

--- a/SA1201ier.MSBuild/build/SA1201ier.MSBuild.targets
+++ b/SA1201ier.MSBuild/build/SA1201ier.MSBuild.targets
@@ -1,6 +1,6 @@
 <Project>
   <UsingTask
-    TaskName="SA1201ier.MSBuild.FormatSA1201Task"
+    TaskName="SA1201ier.MSBuild.FormatSa1201Task"
     AssemblyFile="$(MSBuildThisFileDirectory)\net9.0\SA1201ier.MSBuild.dll"
   />
   <Target
@@ -8,7 +8,7 @@
     BeforeTargets="CSharpierFormat;CoreCompile"
     Condition="'$(SA1201FormatOnBuild)' == 'true' OR '$(SA1201CheckOnBuild)' == 'true'"
   >
-    <FormatSA1201Task
+    <FormatSa1201Task
       ProjectDirectory="$(MSBuildProjectDirectory)"
       CheckOnly="$(SA1201CheckOnBuild)"
       FailOnViolations="$(SA1201FailOnViolations)"


### PR DESCRIPTION
- Added `<CopyLocalLockFileAssemblies>` to copy dependencies to the output directory for packaging in `SA1201ier.MSBuild.csproj`.
- Updated `<None Include>` to include all DLLs except `Microsoft.Build.*.dll` and replaced explicit DLL inclusion with a wildcard pattern.
- Enabled SA1201 formatting by default by setting `SA1201FormatOnBuild` to `true` in `SA1201ier.MSBuild.props`.
- Corrected task name casing from `FormatSA1201Task` to `FormatSa1201Task` in `SA1201ier.MSBuild.targets`.