### PR TITLE
Add multi-targeting support and improve dev experience

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        dotnet-version: ['9.0.x']
+        dotnet-version: ['6.0.x', '8.0.x', '9.0.x']
 
     steps:
     - uses: actions/checkout@v3
@@ -32,11 +32,11 @@ jobs:
       run: dotnet test SA1201ier.slnx --no-build --configuration Release --verbosity normal
 
     - name: Pack NuGet packages
-      if: matrix.os == 'ubuntu-latest'
+      if: matrix.os == 'ubuntu-latest' && matrix.dotnet-version == '9.0.x'
       run: dotnet pack SA1201ier.slnx --no-build --configuration Release --output ./artifacts
 
     - name: Upload artifacts
-      if: matrix.os == 'ubuntu-latest'
+      if: matrix.os == 'ubuntu-latest' && matrix.dotnet-version == '9.0.x'
       uses: actions/upload-artifact@v4
       with:
         name: nuget-packages
@@ -45,6 +45,16 @@ jobs:
   test-cli:
     runs-on: ubuntu-latest
     needs: build-and-test
+    strategy:
+      matrix:
+        framework: ['net6.0', 'net8.0', 'net9.0']
+        include:
+          - framework: 'net6.0'
+            dotnet-version: '6.0.x'
+          - framework: 'net8.0'
+            dotnet-version: '8.0.x'
+          - framework: 'net9.0'
+            dotnet-version: '9.0.x'
 
     steps:
     - uses: actions/checkout@v3
@@ -52,7 +62,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: '9.0.x'
+        dotnet-version: ${{ matrix.dotnet-version }}
 
     - name: Build CLI
       run: dotnet build SA1201ier.Cli/SA1201ier.csproj --configuration Release
@@ -68,16 +78,16 @@ jobs:
         EOF
 
     - name: Run CLI check
-      run: dotnet run --project SA1201ier.Cli/SA1201ier.csproj --no-build --configuration Release -- TestFile.cs --check || true
+      run: dotnet run --project SA1201ier.Cli/SA1201ier.csproj --framework ${{ matrix.framework }} --no-build --configuration Release -- TestFile.cs --check || true
 
     - name: Run CLI format
-      run: dotnet run --project SA1201ier.Cli/SA1201ier.csproj --no-build --configuration Release -- TestFile.cs
+      run: dotnet run --project SA1201ier.Cli/SA1201ier.csproj --framework ${{ matrix.framework }} --no-build --configuration Release -- TestFile.cs
 
     - name: Verify formatting
       run: |
         if grep -q "public void PublicMethod" TestFile.cs; then
-          echo "File was formatted successfully"
+          echo "File was formatted successfully on ${{ matrix.framework }}"
         else
-          echo "File formatting failed"
+          echo "File formatting failed on ${{ matrix.framework }}"
           exit 1
         fi

--- a/SA1201ier.Cli/SA1201ier.csproj
+++ b/SA1201ier.Cli/SA1201ier.csproj
@@ -4,7 +4,9 @@
   </ItemGroup>
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <!-- Target .NET 6.0 and later for broader compatibility -->
+    <TargetFrameworks>net6.0;net8.0;net9.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackAsTool>true</PackAsTool>
@@ -12,7 +14,7 @@
     <PackageId>SA1201ier</PackageId>
     <Title>SA1201ier Formatter CLI Tool</Title>
     <Authors>Chris Wilson</Authors>
-    <Description>Command-line tool for SA1201 Formatter - automatically format C# files according to StyleCop rule SA1201 (elements should be ordered by access level).</Description>
+    <Description>Command-line tool for SA1201 Formatter - automatically format C# files according to StyleCop rule SA1201 (elements should be ordered by access level). Supports .NET 6.0 and later.</Description>
     <PackageTags>stylecop;sa1201;formatter;cli;tool;csharp;code-formatter;dotnet-tool</PackageTags>
     <PackageProjectUrl>https://github.com/ChristopherRWilson/SA1201ier</PackageProjectUrl>
     <RepositoryUrl>https://github.com/ChristopherRWilson/SA1201ier</RepositoryUrl>

--- a/SA1201ier.Core/SA1201ier.Core.csproj
+++ b/SA1201ier.Core/SA1201ier.Core.csproj
@@ -1,13 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <!-- Target .NET 6.0 and later for broader compatibility -->
+    <TargetFrameworks>net6.0;net8.0;net9.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageId>SA1201ier.Core</PackageId>
     <Title>SA1201ier Core Library</Title>
     <Authors>Chris Wilson</Authors>
-    <Description>Core library for SA1201ier - automatically format C# files according to StyleCop rule SA1201 (elements should be ordered by access level).</Description>
+    <Description>Core library for SA1201ier - automatically format C# files according to StyleCop rule SA1201 (elements should be ordered by access level). Supports .NET 6.0 and later.</Description>
     <PackageTags>stylecop;sa1201;formatter;roslyn;csharp;code-formatter</PackageTags>
     <PackageProjectUrl>https://github.com/ChristopherRWilson/SA1201ier</PackageProjectUrl>
     <RepositoryUrl>https://github.com/ChristopherRWilson/SA1201ier</RepositoryUrl>
@@ -24,8 +26,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="[4.8.0,5.0.0)" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Enums\" />
+    <!-- Polyfill for C# 11 features on .NET 6 -->
+    <PackageReference Include="PolySharp" Version="1.14.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/SA1201ier.MSBuild/SA1201ier.MSBuild.csproj
+++ b/SA1201ier.MSBuild/SA1201ier.MSBuild.csproj
@@ -1,13 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <!-- Target .NET 6.0 and later for broader compatibility -->
+    <TargetFrameworks>net6.0;net8.0;net9.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
     <PackageId>SA1201ier.MSBuild</PackageId>
     <Title>SA1201ier MSBuild Integration</Title>
     <Authors>Chris Wilson</Authors>
-    <Description>MSBuild integration for SA1201ier - automatically format C# files according to StyleCop rule SA1201 during build.</Description>
+    <Description>MSBuild integration for SA1201ier - automatically format C# files according to StyleCop rule SA1201 during build. Supports .NET 6.0 and later.</Description>
     <PackageTags>stylecop;sa1201;formatter;msbuild;csharp;code-formatter;build</PackageTags>
     <PackageProjectUrl>https://github.com/ChristopherRWilson/SA1201ier</PackageProjectUrl>
     <RepositoryUrl>https://github.com/ChristopherRWilson/SA1201ier</RepositoryUrl>
@@ -18,6 +20,8 @@
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <!-- Copy all dependencies to output directory so they can be packaged -->
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <!-- Generate runtime config for the task -->
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\README.md" Pack="true" PackagePath="\" />
@@ -38,12 +42,40 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="build\**" Pack="true" PackagePath="build\" />
-    <!-- Include all DLLs from output directory except MSBuild assemblies -->
-    <None
-      Include="$(OutputPath)\*.dll"
-      Pack="true"
-      PackagePath="build\net9.0\"
-      Exclude="$(OutputPath)\Microsoft.Build.*.dll"
-    />
   </ItemGroup>
+  <!-- Package files for each target framework after build -->
+  <Target Name="PackTaskDependencies" AfterTargets="Build" Condition="'$(TargetFramework)' != ''">
+    <ItemGroup>
+      <!-- Include all DLLs except MSBuild assemblies -->
+      <TfmSpecificPackageFile
+        Include="$(OutputPath)*.dll"
+        Exclude="$(OutputPath)Microsoft.Build.*.dll"
+      >
+        <PackagePath>build\$(TargetFramework)\</PackagePath>
+        <Pack>true</Pack>
+        <Visible>false</Visible>
+      </TfmSpecificPackageFile>
+      <!-- Include deps.json -->
+      <TfmSpecificPackageFile
+        Include="$(OutputPath)$(AssemblyName).deps.json"
+        Condition="Exists('$(OutputPath)$(AssemblyName).deps.json')"
+      >
+        <PackagePath>build\$(TargetFramework)\</PackagePath>
+        <Pack>true</Pack>
+        <Visible>false</Visible>
+      </TfmSpecificPackageFile>
+      <!-- Include runtimeconfig.json -->
+      <TfmSpecificPackageFile
+        Include="$(OutputPath)$(AssemblyName).runtimeconfig.json"
+        Condition="Exists('$(OutputPath)$(AssemblyName).runtimeconfig.json')"
+      >
+        <PackagePath>build\$(TargetFramework)\</PackagePath>
+        <Pack>true</Pack>
+        <Visible>false</Visible>
+      </TfmSpecificPackageFile>
+    </ItemGroup>
+    <ItemGroup>
+      <None Include="@(TfmSpecificPackageFile)" />
+    </ItemGroup>
+  </Target>
 </Project>

--- a/SA1201ier.MSBuild/build/SA1201ier.MSBuild.targets
+++ b/SA1201ier.MSBuild/build/SA1201ier.MSBuild.targets
@@ -1,8 +1,24 @@
 <Project>
-  <UsingTask
-    TaskName="SA1201ier.MSBuild.FormatSa1201Task"
-    AssemblyFile="$(MSBuildThisFileDirectory)\net9.0\SA1201ier.MSBuild.dll"
-  />
+  <!-- Determine which target framework to use based on the project's target framework -->
+  <PropertyGroup>
+    <SA1201TaskPath
+      Condition="'$(MSBuildRuntimeType)' == 'Core' AND '$(TargetFramework)' != '' AND $(TargetFramework.StartsWith('net9'))"
+      >$(MSBuildThisFileDirectory)net9.0\SA1201ier.MSBuild.dll</SA1201TaskPath
+    >
+    <SA1201TaskPath
+      Condition="'$(MSBuildRuntimeType)' == 'Core' AND '$(TargetFramework)' != '' AND $(TargetFramework.StartsWith('net8'))"
+      >$(MSBuildThisFileDirectory)net8.0\SA1201ier.MSBuild.dll</SA1201TaskPath
+    >
+    <SA1201TaskPath
+      Condition="'$(MSBuildRuntimeType)' == 'Core' AND '$(TargetFramework)' != '' AND $(TargetFramework.StartsWith('net6'))"
+      >$(MSBuildThisFileDirectory)net6.0\SA1201ier.MSBuild.dll</SA1201TaskPath
+    >
+    <!-- Default to net6.0 if no match or for older frameworks -->
+    <SA1201TaskPath Condition="'$(SA1201TaskPath)' == ''"
+      >$(MSBuildThisFileDirectory)net6.0\SA1201ier.MSBuild.dll</SA1201TaskPath
+    >
+  </PropertyGroup>
+  <UsingTask TaskName="SA1201ier.MSBuild.FormatSa1201Task" AssemblyFile="$(SA1201TaskPath)" />
   <Target
     Name="FormatSA1201"
     BeforeTargets="CSharpierFormat;CoreCompile"

--- a/VS_BUILD_FIX.md
+++ b/VS_BUILD_FIX.md
@@ -1,0 +1,53 @@
+# Fixing Visual Studio Build Errors After Multi-Targeting Changes
+
+If you're getting errors about missing target frameworks in Visual Studio after the multi-targeting changes, follow these steps:
+
+## Solution
+
+### Option 1: Using the Cleanup Script (Recommended)
+
+**Windows:**
+1. **Close Visual Studio completely**
+2. Run `clean-vs-cache.cmd` (double-click or run from command prompt)
+3. Reopen the solution in Visual Studio
+
+**Linux/Mac:**
+```bash
+./clean-vs-cache.sh
+```
+
+### Option 2: Manual Cleanup
+
+**Close Visual Studio completely** before running these commands:
+
+```bash
+# Windows PowerShell
+Remove-Item -Recurse -Force .vs, */obj, */bin
+dotnet restore
+
+# Linux/Mac or Git Bash
+rm -rf .vs */obj */bin
+dotnet restore
+```
+
+### Option 3: Within Visual Studio
+
+1. Close the solution
+2. Go to Tools → NuGet Package Manager → Package Manager Settings
+3. Click "Clear All NuGet Cache(s)"
+4. Close Visual Studio
+5. Delete the `.vs` folder in the solution directory
+6. Reopen Visual Studio and the solution
+7. Right-click the solution → Restore NuGet Packages
+8. Rebuild the solution
+
+## Why This Happens
+
+When switching from single-targeting (`net9.0`) to multi-targeting (`net6.0;net8.0;net9.0`), both Visual Studio and the .NET CLI cache asset files (`project.assets.json`) that become invalid. Visual Studio maintains its own cache in the `.vs` folder, which needs to be cleared separately from the command-line `obj` and `bin` folders.
+
+## Prevention
+
+After making project file changes (especially to `TargetFramework` or `TargetFrameworks`):
+1. Close Visual Studio before building from command line
+2. OR do a "Clean Solution" in Visual Studio before rebuilding
+3. Keep the cleanup scripts handy for future use

--- a/clean-vs-cache.cmd
+++ b/clean-vs-cache.cmd
@@ -1,0 +1,20 @@
+@echo off
+REM Clean Visual Studio and build caches
+echo Cleaning Visual Studio and build caches...
+
+REM Remove Visual Studio cache
+if exist .vs rd /s /q .vs
+echo Removed .vs folder
+
+REM Remove obj and bin folders from all projects
+for /d /r %%d in (obj) do @if exist "%%d" rd /s /q "%%d"
+for /d /r %%d in (bin) do @if exist "%%d" rd /s /q "%%d"
+echo Removed obj and bin folders
+
+REM Restore packages
+echo Restoring NuGet packages...
+dotnet restore
+
+echo.
+echo Done! You can now open the solution in Visual Studio.
+pause

--- a/clean-vs-cache.sh
+++ b/clean-vs-cache.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Clean Visual Studio and build caches
+echo "Cleaning Visual Studio and build caches..."
+
+# Remove Visual Studio cache
+if [ -d ".vs" ]; then
+    rm -rf .vs
+    echo "Removed .vs folder"
+fi
+
+# Remove obj and bin folders from all projects
+find . -type d -name "obj" -exec rm -rf {} + 2>/dev/null
+find . -type d -name "bin" -exec rm -rf {} + 2>/dev/null
+echo "Removed obj and bin folders"
+
+# Restore packages
+echo "Restoring NuGet packages..."
+dotnet restore
+
+echo ""
+echo "Done! You can now open the solution in Visual Studio."


### PR DESCRIPTION
Updated project files to support .NET 6.0, 8.0, and 9.0 for broader compatibility. Enabled latest C# features with `<LangVersion>latest</LangVersion>`. Added `PolySharp` to backport C# 11 features for .NET 6.0.

Enhanced `SA1201ier.MSBuild.csproj` to include runtime configuration files and introduced `PackTaskDependencies` for framework-specific packaging. Updated `SA1201ier.MSBuild.targets` to dynamically resolve MSBuild task paths based on the target framework.

Added `VS_BUILD_FIX.md` with instructions to resolve Visual Studio build issues after multi-targeting changes. Introduced cleanup scripts (`clean-vs-cache.cmd` and `clean-vs-cache.sh`) to automate clearing caches and restoring packages.

Improves compatibility, maintainability, and developer experience.