### PR TITLE
Simplify SA1201 task path resolution logic

### DIFF
--- a/SA1201ier.MSBuild/build/SA1201ier.MSBuild.targets
+++ b/SA1201ier.MSBuild/build/SA1201ier.MSBuild.targets
@@ -2,16 +2,21 @@
   <!-- Determine which target framework to use based on available .NET SDK -->
   <PropertyGroup>
     <!-- Try to detect the best matching framework based on the target framework -->
-    <SA1201TaskPath Condition="'$(SA1201TaskPath)' == '' AND '$(TargetFramework)' != ''">$(MSBuildThisFileDirectory)$(TargetFramework)\SA1201ier.MSBuild.dll</SA1201TaskPath>
-    
+    <SA1201TaskPath Condition="'$(SA1201TaskPath)' == '' AND '$(TargetFramework)' != ''"
+      >$(MSBuildThisFileDirectory)$(TargetFramework)\SA1201ier.MSBuild.dll</SA1201TaskPath
+    >
     <!-- Fall back to checking if specific framework folders exist -->
-    <SA1201TaskPath Condition="'$(SA1201TaskPath)' == '' OR !Exists('$(SA1201TaskPath)')">$(MSBuildThisFileDirectory)net9.0\SA1201ier.MSBuild.dll</SA1201TaskPath>
-    <SA1201TaskPath Condition="!Exists('$(SA1201TaskPath)')">$(MSBuildThisFileDirectory)net8.0\SA1201ier.MSBuild.dll</SA1201TaskPath>
-    <SA1201TaskPath Condition="!Exists('$(SA1201TaskPath)')">$(MSBuildThisFileDirectory)net6.0\SA1201ier.MSBuild.dll</SA1201TaskPath>
+    <SA1201TaskPath Condition="'$(SA1201TaskPath)' == '' OR !Exists('$(SA1201TaskPath)')"
+      >$(MSBuildThisFileDirectory)net9.0\SA1201ier.MSBuild.dll</SA1201TaskPath
+    >
+    <SA1201TaskPath Condition="!Exists('$(SA1201TaskPath)')"
+      >$(MSBuildThisFileDirectory)net8.0\SA1201ier.MSBuild.dll</SA1201TaskPath
+    >
+    <SA1201TaskPath Condition="!Exists('$(SA1201TaskPath)')"
+      >$(MSBuildThisFileDirectory)net6.0\SA1201ier.MSBuild.dll</SA1201TaskPath
+    >
   </PropertyGroup>
-  
   <UsingTask TaskName="SA1201ier.MSBuild.FormatSa1201Task" AssemblyFile="$(SA1201TaskPath)" />
-  
   <Target
     Name="FormatSA1201"
     BeforeTargets="CSharpierFormat;CoreCompile"

--- a/SA1201ier.MSBuild/build/SA1201ier.MSBuild.targets
+++ b/SA1201ier.MSBuild/build/SA1201ier.MSBuild.targets
@@ -1,24 +1,17 @@
 <Project>
-  <!-- Determine which target framework to use based on the project's target framework -->
+  <!-- Determine which target framework to use based on available .NET SDK -->
   <PropertyGroup>
-    <SA1201TaskPath
-      Condition="'$(MSBuildRuntimeType)' == 'Core' AND '$(TargetFramework)' != '' AND $(TargetFramework.StartsWith('net9'))"
-      >$(MSBuildThisFileDirectory)net9.0\SA1201ier.MSBuild.dll</SA1201TaskPath
-    >
-    <SA1201TaskPath
-      Condition="'$(MSBuildRuntimeType)' == 'Core' AND '$(TargetFramework)' != '' AND $(TargetFramework.StartsWith('net8'))"
-      >$(MSBuildThisFileDirectory)net8.0\SA1201ier.MSBuild.dll</SA1201TaskPath
-    >
-    <SA1201TaskPath
-      Condition="'$(MSBuildRuntimeType)' == 'Core' AND '$(TargetFramework)' != '' AND $(TargetFramework.StartsWith('net6'))"
-      >$(MSBuildThisFileDirectory)net6.0\SA1201ier.MSBuild.dll</SA1201TaskPath
-    >
-    <!-- Default to net6.0 if no match or for older frameworks -->
-    <SA1201TaskPath Condition="'$(SA1201TaskPath)' == ''"
-      >$(MSBuildThisFileDirectory)net6.0\SA1201ier.MSBuild.dll</SA1201TaskPath
-    >
+    <!-- Try to detect the best matching framework based on the target framework -->
+    <SA1201TaskPath Condition="'$(SA1201TaskPath)' == '' AND '$(TargetFramework)' != ''">$(MSBuildThisFileDirectory)$(TargetFramework)\SA1201ier.MSBuild.dll</SA1201TaskPath>
+    
+    <!-- Fall back to checking if specific framework folders exist -->
+    <SA1201TaskPath Condition="'$(SA1201TaskPath)' == '' OR !Exists('$(SA1201TaskPath)')">$(MSBuildThisFileDirectory)net9.0\SA1201ier.MSBuild.dll</SA1201TaskPath>
+    <SA1201TaskPath Condition="!Exists('$(SA1201TaskPath)')">$(MSBuildThisFileDirectory)net8.0\SA1201ier.MSBuild.dll</SA1201TaskPath>
+    <SA1201TaskPath Condition="!Exists('$(SA1201TaskPath)')">$(MSBuildThisFileDirectory)net6.0\SA1201ier.MSBuild.dll</SA1201TaskPath>
   </PropertyGroup>
+  
   <UsingTask TaskName="SA1201ier.MSBuild.FormatSa1201Task" AssemblyFile="$(SA1201TaskPath)" />
+  
   <Target
     Name="FormatSA1201"
     BeforeTargets="CSharpierFormat;CoreCompile"


### PR DESCRIPTION
Refactor the logic for determining `SA1201TaskPath`:
- Replace hardcoded framework-specific conditions with a dynamic approach using `TargetFramework`.
- Add fallback logic to check for specific framework folders (`net9.0`, `net8.0`, `net6.0`) in descending order of version.

Introduce the `FormatSA1201` target:
- Configured to run before `CSharpierFormat` and `CoreCompile`.
- Conditionally executed based on `SA1201FormatOnBuild` or `SA1201CheckOnBuild` properties.

Update comments to reflect the new framework resolution logic.