### PR TITLE
Enhance NuGet packaging process for localization and runtime

### DIFF
--- a/SA1201ier.MSBuild/SA1201ier.MSBuild.csproj
+++ b/SA1201ier.MSBuild/SA1201ier.MSBuild.csproj
@@ -48,7 +48,7 @@
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);PackTaskDependencies</TargetsForTfmSpecificContentInPackage>
   </PropertyGroup>
   <!-- Package files for each target framework - this runs once per TFM during inner builds -->
-  <Target Name="PackTaskDependencies" DependsOnTargets="Build">
+  <Target Name="PackTaskDependencies">
     <ItemGroup>
       <!-- Include all DLLs except MSBuild assemblies -->
       <TfmSpecificPackageFile

--- a/SA1201ier.MSBuild/SA1201ier.MSBuild.csproj
+++ b/SA1201ier.MSBuild/SA1201ier.MSBuild.csproj
@@ -43,8 +43,12 @@
   <ItemGroup>
     <None Include="build\**" Pack="true" PackagePath="build\" />
   </ItemGroup>
-  <!-- Package files for each target framework after build -->
-  <Target Name="PackTaskDependencies" AfterTargets="Build" Condition="'$(TargetFramework)' != ''">
+  <!-- This property tells NuGet to call our custom target during pack -->
+  <PropertyGroup>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);PackTaskDependencies</TargetsForTfmSpecificContentInPackage>
+  </PropertyGroup>
+  <!-- Package files for each target framework - this runs once per TFM during inner builds -->
+  <Target Name="PackTaskDependencies" DependsOnTargets="Build">
     <ItemGroup>
       <!-- Include all DLLs except MSBuild assemblies -->
       <TfmSpecificPackageFile
@@ -52,8 +56,6 @@
         Exclude="$(OutputPath)Microsoft.Build.*.dll"
       >
         <PackagePath>build\$(TargetFramework)\</PackagePath>
-        <Pack>true</Pack>
-        <Visible>false</Visible>
       </TfmSpecificPackageFile>
       <!-- Include deps.json -->
       <TfmSpecificPackageFile
@@ -61,8 +63,6 @@
         Condition="Exists('$(OutputPath)$(AssemblyName).deps.json')"
       >
         <PackagePath>build\$(TargetFramework)\</PackagePath>
-        <Pack>true</Pack>
-        <Visible>false</Visible>
       </TfmSpecificPackageFile>
       <!-- Include runtimeconfig.json -->
       <TfmSpecificPackageFile
@@ -70,12 +70,21 @@
         Condition="Exists('$(OutputPath)$(AssemblyName).runtimeconfig.json')"
       >
         <PackagePath>build\$(TargetFramework)\</PackagePath>
-        <Pack>true</Pack>
-        <Visible>false</Visible>
       </TfmSpecificPackageFile>
     </ItemGroup>
+    <!-- Include localization resource DLLs -->
     <ItemGroup>
-      <None Include="@(TfmSpecificPackageFile)" />
+      <_LocalizationFiles Include="$(OutputPath)cs\**\*.dll;$(OutputPath)de\**\*.dll;$(OutputPath)es\**\*.dll;$(OutputPath)fr\**\*.dll;$(OutputPath)it\**\*.dll;$(OutputPath)ja\**\*.dll;$(OutputPath)ko\**\*.dll;$(OutputPath)pl\**\*.dll;$(OutputPath)pt-BR\**\*.dll;$(OutputPath)ru\**\*.dll;$(OutputPath)tr\**\*.dll;$(OutputPath)zh-Hans\**\*.dll;$(OutputPath)zh-Hant\**\*.dll" />
+      <TfmSpecificPackageFile Include="@(_LocalizationFiles)">
+        <PackagePath>build\$(TargetFramework)\%(RecursiveDir)%(Filename)%(Extension)</PackagePath>
+      </TfmSpecificPackageFile>
+    </ItemGroup>
+    <!-- Include runtime-specific native assemblies -->
+    <ItemGroup>
+      <_RuntimeFiles Include="$(OutputPath)runtimes\**\*.dll" />
+      <TfmSpecificPackageFile Include="@(_RuntimeFiles)">
+        <PackagePath>build\$(TargetFramework)\%(RecursiveDir)%(Filename)%(Extension)</PackagePath>
+      </TfmSpecificPackageFile>
     </ItemGroup>
   </Target>
 </Project>

--- a/SA1201ier.MSBuild/SA1201ier.MSBuild.csproj
+++ b/SA1201ier.MSBuild/SA1201ier.MSBuild.csproj
@@ -74,7 +74,10 @@
     </ItemGroup>
     <!-- Include localization resource DLLs -->
     <ItemGroup>
-      <_LocalizationFiles Include="$(OutputPath)cs\**\*.dll;$(OutputPath)de\**\*.dll;$(OutputPath)es\**\*.dll;$(OutputPath)fr\**\*.dll;$(OutputPath)it\**\*.dll;$(OutputPath)ja\**\*.dll;$(OutputPath)ko\**\*.dll;$(OutputPath)pl\**\*.dll;$(OutputPath)pt-BR\**\*.dll;$(OutputPath)ru\**\*.dll;$(OutputPath)tr\**\*.dll;$(OutputPath)zh-Hans\**\*.dll;$(OutputPath)zh-Hant\**\*.dll" />
+      <_LocalizationFiles
+        Include="$(OutputPath)*\**\*.dll"
+        Exclude="$(OutputPath)$(AssemblyName).dll;$(OutputPath)Microsoft.Build.*.dll;$(OutputPath)runtimes\**\*.dll"
+      />
       <TfmSpecificPackageFile Include="@(_LocalizationFiles)">
         <PackagePath>build\$(TargetFramework)\%(RecursiveDir)%(Filename)%(Extension)</PackagePath>
       </TfmSpecificPackageFile>


### PR DESCRIPTION
- Added `<PropertyGroup>` to integrate `PackTaskDependencies` into the NuGet pack workflow via `TargetsForTfmSpecificContentInPackage`.
- Modified `PackTaskDependencies` target to run per TFM during inner builds and depend on the `Build` target.
- Removed `<Pack>` and `<Visible>` metadata from `<TfmSpecificPackageFile>` items for `.dll`, `.deps.json`, and `.runtimeconfig.json` files.
- Added support for packaging localization resource DLLs for multiple languages under `build\$(TargetFramework)\%(RecursiveDir)%(Filename)%(Extension)`.
- Included runtime-specific native assemblies from `runtimes\**\*.dll` in the package under the same path structure.
- Removed `<None Include="@(TfmSpecificPackageFile)" />` as it is no longer needed.
- Improved overall packaging logic for better extensibility and clarity.