### PR TITLE
Simplify project configuration for net6.0

### DIFF
--- a/SA1201ier.MSBuild/SA1201ier.MSBuild.csproj
+++ b/SA1201ier.MSBuild/SA1201ier.MSBuild.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- MSBuild task targets only host-supported frameworks; consumer projects can be newer -->
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -18,10 +17,8 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <DevelopmentDependency>true</DevelopmentDependency>
     <IncludeBuildOutput>false</IncludeBuildOutput>
-    <!-- Copy all dependencies to output directory so they can be packaged -->
-    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <!-- Generate runtime config for the task -->
-    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
+    <GenerateRuntimeConfigurationFiles>false</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\README.md" Pack="true" PackagePath="\" />

--- a/SA1201ier.MSBuild/build/SA1201ier.MSBuild.targets
+++ b/SA1201ier.MSBuild/build/SA1201ier.MSBuild.targets
@@ -1,16 +1,7 @@
 <Project>
   <!-- Determine which target framework to use based on available .NET SDK -->
   <PropertyGroup>
-    <!-- Select task assembly for supported host frameworks (.NET 8 first, then 6) -->
-    <SA1201TaskPath Condition="'$(SA1201TaskPath)' == '' AND '$(TargetFramework)' != ''"
-      >$(MSBuildThisFileDirectory)$(TargetFramework)\SA1201ier.MSBuild.dll</SA1201TaskPath
-    >
-    <SA1201TaskPath Condition="'$(SA1201TaskPath)' == '' OR !Exists('$(SA1201TaskPath)')"
-      >$(MSBuildThisFileDirectory)net8.0\SA1201ier.MSBuild.dll</SA1201TaskPath
-    >
-    <SA1201TaskPath Condition="!Exists('$(SA1201TaskPath)')"
-      >$(MSBuildThisFileDirectory)net6.0\SA1201ier.MSBuild.dll</SA1201TaskPath
-    >
+    <SA1201TaskPath>$(MSBuildThisFileDirectory)net6.0\SA1201ier.MSBuild.dll</SA1201TaskPath>
   </PropertyGroup>
   <UsingTask TaskName="SA1201ier.MSBuild.FormatSa1201Task" AssemblyFile="$(SA1201TaskPath)" />
   <Target


### PR DESCRIPTION
Refactor project to target only net6.0:
- Replace `<TargetFrameworks>` with `<TargetFramework>` to remove multi-targeting for net6.0 and net8.0.
- Disable copying of dependencies and runtime configuration file generation by setting `<CopyLocalLockFileAssemblies>` and `<GenerateRuntimeConfigurationFiles>` to `false`.
- Simplify `SA1201TaskPath` resolution in `SA1201ier.MSBuild.targets` to use a hardcoded path for net6.0.
- Adjust `<Project>` tag indentation for consistency.

These changes reduce complexity and streamline the build process.