### PR TITLE
Support multiple .NET frameworks and dynamic MSBuild logic

### DIFF
--- a/.csharpierignore
+++ b/.csharpierignore
@@ -1,0 +1,3 @@
+# Exclude MSBuild targets and props files - these are XML, not C#
+*.targets
+*.props

--- a/SA1201ier.MSBuild/SA1201ier.MSBuild.csproj
+++ b/SA1201ier.MSBuild/SA1201ier.MSBuild.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0;net9.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/SA1201ier.MSBuild/build/SA1201ier.MSBuild.targets
+++ b/SA1201ier.MSBuild/build/SA1201ier.MSBuild.targets
@@ -1,7 +1,13 @@
 <Project>
-  <!-- Determine which target framework to use based on available .NET SDK -->
+  <!-- Determine which target framework to use based on MSBuild runtime -->
   <PropertyGroup>
-    <SA1201TaskPath>$(MSBuildThisFileDirectory)net6.0\SA1201ier.MSBuild.dll</SA1201TaskPath>
+    <!-- Default to net6.0 -->
+    <SA1201TaskTfm>net6.0</SA1201TaskTfm>
+    <!-- Use net8.0 if MSBuildRuntimeType is Core and NETCoreSdkVersion is 8.x -->
+    <SA1201TaskTfm Condition="'$(MSBuildRuntimeType)' == 'Core' AND $([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreSdkVersion)', '8.0')) AND $([MSBuild]::VersionLessThan('$(NETCoreSdkVersion)', '9.0'))">net8.0</SA1201TaskTfm>
+    <!-- Use net9.0 if MSBuildRuntimeType is Core and NETCoreSdkVersion is 9.x or higher -->
+    <SA1201TaskTfm Condition="'$(MSBuildRuntimeType)' == 'Core' AND $([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreSdkVersion)', '9.0'))">net9.0</SA1201TaskTfm>
+    <SA1201TaskPath>$(MSBuildThisFileDirectory)$(SA1201TaskTfm)\SA1201ier.MSBuild.dll</SA1201TaskPath>
   </PropertyGroup>
   <UsingTask TaskName="SA1201ier.MSBuild.FormatSa1201Task" AssemblyFile="$(SA1201TaskPath)" />
   <Target

--- a/SA1201ier.MSBuild/build/SA1201ier.MSBuild.targets
+++ b/SA1201ier.MSBuild/build/SA1201ier.MSBuild.targets
@@ -4,9 +4,13 @@
     <!-- Default to net6.0 -->
     <SA1201TaskTfm>net6.0</SA1201TaskTfm>
     <!-- Use net8.0 if MSBuildRuntimeType is Core and NETCoreSdkVersion is 8.x -->
-    <SA1201TaskTfm Condition="'$(MSBuildRuntimeType)' == 'Core' AND $([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreSdkVersion)', '8.0')) AND $([MSBuild]::VersionLessThan('$(NETCoreSdkVersion)', '9.0'))">net8.0</SA1201TaskTfm>
+    <SA1201TaskTfm
+      Condition="'$(MSBuildRuntimeType)' == 'Core' AND $([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreSdkVersion)', '8.0')) AND $([MSBuild]::VersionLessThan('$(NETCoreSdkVersion)', '9.0'))"
+    >net8.0</SA1201TaskTfm>
     <!-- Use net9.0 if MSBuildRuntimeType is Core and NETCoreSdkVersion is 9.x or higher -->
-    <SA1201TaskTfm Condition="'$(MSBuildRuntimeType)' == 'Core' AND $([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreSdkVersion)', '9.0'))">net9.0</SA1201TaskTfm>
+    <SA1201TaskTfm
+      Condition="'$(MSBuildRuntimeType)' == 'Core' AND $([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreSdkVersion)', '9.0'))"
+    >net9.0</SA1201TaskTfm>
     <SA1201TaskPath>$(MSBuildThisFileDirectory)$(SA1201TaskTfm)\SA1201ier.MSBuild.dll</SA1201TaskPath>
   </PropertyGroup>
   <UsingTask TaskName="SA1201ier.MSBuild.FormatSa1201Task" AssemblyFile="$(SA1201TaskPath)" />


### PR DESCRIPTION
Updated `SA1201ier.MSBuild.csproj` to target `net6.0`, `net8.0`, and `net9.0` by replacing `<TargetFramework>` with `<TargetFrameworks>`.

Enhanced `SA1201ier.MSBuild.targets` to dynamically select the appropriate framework (`net6.0`, `net8.0`, or `net9.0`) based on the MSBuild runtime type and .NET SDK version. Introduced the `SA1201TaskTfm` property for dynamic framework resolution and updated `SA1201TaskPath` to use this logic.

These changes improve compatibility and future-proof the project for multiple .NET versions and runtime environments.