### PR TITLE
Enable dynamic loading in MSBuild project file

### DIFF
--- a/SA1201ier.MSBuild/SA1201ier.MSBuild.csproj
+++ b/SA1201ier.MSBuild/SA1201ier.MSBuild.csproj
@@ -19,6 +19,7 @@
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\README.md" Pack="true" PackagePath="\" />


### PR DESCRIPTION
Added the `<EnableDynamicLoading>` property to the `<PropertyGroup>` in `SA1201ier.MSBuild.csproj` with a value of `true`. This change enables dynamic loading functionality, potentially improving runtime flexibility and supporting dynamic assembly/component loading.