### PR TITLE
Refactor SA1201 targets for flexible argument handling

### DIFF
--- a/SA1201ier.MSBuild/build/SA1201ier.MSBuild.targets
+++ b/SA1201ier.MSBuild/build/SA1201ier.MSBuild.targets
@@ -7,8 +7,8 @@
     <SA1201DllPath>$(MSBuildThisFileDirectory)../tools/sa1201ier/$(SA1201_FrameworkVersion)/SA1201ier.dll</SA1201DllPath>
     <SA1201_dotnet_Path Condition="'$(SA1201_dotnet_Path)' == ''">$(DOTNET_HOST_PATH)</SA1201_dotnet_Path>
     <SA1201_dotnet_Path Condition="'$(SA1201_dotnet_Path)' == ''">dotnet</SA1201_dotnet_Path>
-    <SA1201Command>format</SA1201Command>
-    <SA1201Command Condition="'$(SA1201CheckOnBuild)' == 'true'">check</SA1201Command>
+    <SA1201Args></SA1201Args>
+    <SA1201Args Condition="'$(SA1201CheckOnBuild)' == 'true'">--check</SA1201Args>
     <SA1201VerboseOutput Condition="'$(SA1201VerboseOutput)' == ''">false</SA1201VerboseOutput>
     <FirstTargetFramework Condition=" '$(TargetFrameworks)' == '' ">$(TargetFramework)</FirstTargetFramework>
     <FirstTargetFramework Condition=" '$(FirstTargetFramework)' == '' ">$(TargetFrameworks.Split(';')[0])</FirstTargetFramework>
@@ -27,7 +27,7 @@
       StdErrEncoding="utf-8"
       IgnoreExitCode="true"
       Condition="'$(SA1201VerboseOutput)' != 'true'"
-      Command="&quot;$(SA1201_dotnet_Path)&quot; exec &quot;$(SA1201DllPath)&quot; $(SA1201Command) &quot;$(MSBuildProjectDirectory)&quot; &gt; $(NullOutput)"
+      Command="&quot;$(SA1201_dotnet_Path)&quot; exec &quot;$(SA1201DllPath)&quot; &quot;$(MSBuildProjectDirectory)&quot; $(SA1201Args) &gt; $(NullOutput)"
     />
     <!-- With verbose output enabled, show all formatter output -->
     <Exec
@@ -36,7 +36,7 @@
       StdErrEncoding="utf-8"
       IgnoreExitCode="true"
       Condition="'$(SA1201VerboseOutput)' == 'true'"
-      Command="&quot;$(SA1201_dotnet_Path)&quot; exec &quot;$(SA1201DllPath)&quot; $(SA1201Command) &quot;$(MSBuildProjectDirectory)&quot;"
+      Command="&quot;$(SA1201_dotnet_Path)&quot; exec &quot;$(SA1201DllPath)&quot; &quot;$(MSBuildProjectDirectory)&quot; $(SA1201Args)"
     />
   </Target>
 


### PR DESCRIPTION
Replaced the `<SA1201Command>` property with `<SA1201Args>` to enable dynamic argument handling. Updated `<Exec>` tasks to use `<SA1201Args>` instead of hardcoded commands like `format` or `check`. Added conditional logic to set `<SA1201Args>` to `--check` when `SA1201CheckOnBuild` is `true`.

These changes improve maintainability and extensibility by decoupling command logic from hardcoded properties and allowing dynamic construction of command-line arguments.